### PR TITLE
chore: add logging for sync stat reporting

### DIFF
--- a/src/modules/cloudshelf/cloudshelf.api.service.ts
+++ b/src/modules/cloudshelf/cloudshelf.api.service.ts
@@ -449,10 +449,12 @@ export class CloudshelfApiService {
 
     async reportCatalogStats(
         domain: string,
-        knownNumberOfProductGroups?: number,
-        knownNumberOfProducts?: number,
-        knownNumberOfProductVariants?: number,
-        knownNumberOfImages?: number,
+        input: {
+            knownNumberOfProductGroups?: number;
+            knownNumberOfProducts?: number;
+            knownNumberOfProductVariants?: number;
+            knownNumberOfImages?: number;
+        },
         log?: (logMessage: string) => Promise<void>,
     ) {
         const authedClient = await this.getCloudshelfAPIApolloClient(domain);
@@ -463,10 +465,10 @@ export class CloudshelfApiService {
         >({
             mutation: ReportCatalogStatsDocument,
             variables: {
-                knownNumberOfProductGroups,
-                knownNumberOfProducts,
-                knownNumberOfProductVariants,
-                knownNumberOfImages,
+                knownNumberOfProductGroups: input.knownNumberOfProductGroups,
+                knownNumberOfProducts: input.knownNumberOfProducts,
+                knownNumberOfProductVariants: input.knownNumberOfProductVariants,
+                knownNumberOfImages: input.knownNumberOfImages,
             },
         });
 

--- a/src/modules/data-ingestion/product/product.processor.ts
+++ b/src/modules/data-ingestion/product/product.processor.ts
@@ -519,13 +519,18 @@ export class ProductProcessor implements OnApplicationBootstrap {
         await this.nobleService.addTimedLogMessage(task, `Deleting downloaded data file: ${tempFile}`);
         await fsPromises.unlink(tempFile);
 
-        await this.cloudshelfApiService.reportCatalogStats(
-            retailer.domain,
-            undefined,
-            productInputs.length,
-            variantInputs.length,
-            imageCount,
+        const input = {
+            knownNumberOfProductGroups: undefined,
+            knownNumberOfProducts: productInputs.length,
+            knownNumberOfProductVariants: variantInputs.length,
+            knownNumberOfImages: imageCount,
+        };
+        await this.nobleService.addTimedLogMessage(
+            task,
+            `Reporting catalog stats to cloudshelf: ${JSON.stringify(input)}`,
+            true,
         );
+        await this.cloudshelfApiService.reportCatalogStats(retailer.domain, input);
 
         await handleComplete(retailer);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the method for reporting catalog statistics in the Cloudshelf service by accepting a consolidated input object for better flexibility and readability.
	- Enhanced logging for catalog statistics reporting to include detailed input parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->