### PR TITLE
feat: call keepKnownProductGroupsViaFile during sync

### DIFF
--- a/src/graphql/cloudshelf/generated/cloudshelf.schema.json
+++ b/src/graphql/cloudshelf/generated/cloudshelf.schema.json
@@ -955,13 +955,9 @@
             "description": "The key for the value",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -8826,6 +8822,22 @@
         "description": null,
         "fields": [
           {
+            "name": "imageCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "productCount",
             "description": null,
             "args": [],
@@ -11037,6 +11049,39 @@
             "deprecationReason": null
           },
           {
+            "name": "keepKnownProductGroupsViaFile",
+            "description": "Allows the user to provide a file with known product variants to keep, any other product groups already in their organisation will be deleted. (with the exception of the all products group)",
+            "args": [
+              {
+                "name": "fileUrl",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProductGroupDeletionPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "keepKnownProductsViaFile",
             "description": "Allows the user to provide a file with known products to keep, any other products already in their organisation will be deleted",
             "args": [
@@ -11422,7 +11467,7 @@
             "args": [
               {
                 "name": "knownNumberOfImages",
-                "description": null,
+                "description": "The number of variant images that the organisation knows it has",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -16632,6 +16677,57 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ProductGroupDeletionPayload",
+        "description": null,
+        "fields": [
+          {
+            "name": "count",
+            "description": "The number of product groups that were removed from the organisation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userErrors",
+            "description": "An array of errors that occurred during the delete operation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "UserError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ProductGroupEdge",
         "description": null,
         "fields": [
@@ -18511,7 +18607,20 @@
           {
             "name": "ingestionStats",
             "description": null,
-            "args": [],
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "GlobalId",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,

--- a/src/graphql/cloudshelf/generated/cloudshelf.ts
+++ b/src/graphql/cloudshelf/generated/cloudshelf.ts
@@ -141,7 +141,7 @@ export type CatalogStats = {
   extraInformation: Scalars['String']['output'];
   numberHeldAtTimeOfReporting: Scalars['Float']['output'];
   /** The key for the value */
-  reportedAt: Scalars['DateTime']['output'];
+  reportedAt?: Maybe<Scalars['DateTime']['output']>;
 };
 
 /** Selects how the cloudshelf handles the checkout experience. */
@@ -1380,6 +1380,7 @@ export type IncludablePdpBlock = {
 
 export type IngestionStatsPayload = {
   __typename?: 'IngestionStatsPayload';
+  imageCount: Scalars['Int']['output'];
   productCount: Scalars['Int']['output'];
   productGroupCount: Scalars['Int']['output'];
   productGroupWithValidProductCount: Scalars['Int']['output'];
@@ -1613,6 +1614,8 @@ export type Mutation = {
   duplicateThemes: ThemeDuplicatePayload;
   editSubscription: SubscriptionRecord;
   endSession: Session;
+  /** Allows the user to provide a file with known product variants to keep, any other product groups already in their organisation will be deleted. (with the exception of the all products group) */
+  keepKnownProductGroupsViaFile: ProductGroupDeletionPayload;
   /** Allows the user to provide a file with known products to keep, any other products already in their organisation will be deleted */
   keepKnownProductsViaFile: ProductDeletionPayload;
   /** Allows the user to provide a file with known variants to keep, any other variants already in their organisation will be deleted */
@@ -1763,6 +1766,11 @@ export type MutationEditSubscriptionArgs = {
 export type MutationEndSessionArgs = {
   id: Scalars['GlobalId']['input'];
   interactions: Scalars['Int']['input'];
+};
+
+
+export type MutationKeepKnownProductGroupsViaFileArgs = {
+  fileUrl: Scalars['String']['input'];
 };
 
 
@@ -2474,6 +2482,14 @@ export type ProductGroupDeletePayload = {
   userErrors: Array<UserError>;
 };
 
+export type ProductGroupDeletionPayload = {
+  __typename?: 'ProductGroupDeletionPayload';
+  /** The number of product groups that were removed from the organisation */
+  count: Scalars['Int']['output'];
+  /** An array of errors that occurred during the delete operation */
+  userErrors: Array<UserError>;
+};
+
 export type ProductGroupEdge = {
   __typename?: 'ProductGroupEdge';
   /** The cursor for provided node to be used in pagination */
@@ -2813,6 +2829,11 @@ export type QueryGetVersionByTypeArgs = {
 
 export type QueryIncludeableFiltersArgs = {
   cloudshelfId: Scalars['GlobalId']['input'];
+};
+
+
+export type QueryIngestionStatsArgs = {
+  id?: InputMaybe<Scalars['GlobalId']['input']>;
 };
 
 
@@ -3835,6 +3856,17 @@ export const DeleteProductGroupsDocument = gql`
   }
 }
     `;
+export const KeepKnownProductGroupsViaFileDocument = gql`
+    mutation keepKnownProductGroupsViaFile($fileUrl: String!) {
+  keepKnownProductGroupsViaFile(fileUrl: $fileUrl) {
+    count
+    userErrors {
+      code
+      message
+    }
+  }
+}
+    `;
 export const UpsertProductsDocument = gql`
     mutation upsertProducts($input: [ProductInput!]!) {
   upsertProducts(input: $input) {
@@ -3994,6 +4026,13 @@ export type DeleteProductGroupsMutationVariables = Exact<{
 
 
 export type DeleteProductGroupsMutation = { __typename?: 'Mutation', deleteProductGroups: { __typename?: 'ProductGroupDeletePayload', productGroups: Array<{ __typename?: 'ProductGroup', id: any }>, userErrors: Array<{ __typename?: 'UserError', code: UserErrorCode, message: string }> } };
+
+export type KeepKnownProductGroupsViaFileMutationVariables = Exact<{
+  fileUrl: Scalars['String']['input'];
+}>;
+
+
+export type KeepKnownProductGroupsViaFileMutation = { __typename?: 'Mutation', keepKnownProductGroupsViaFile: { __typename?: 'ProductGroupDeletionPayload', count: number, userErrors: Array<{ __typename?: 'UserError', code: UserErrorCode, message: string }> } };
 
 export type UpsertProductsMutationVariables = Exact<{
   input: Array<ProductInput> | ProductInput;

--- a/src/graphql/cloudshelf/mutations/ProductGroup.graphql
+++ b/src/graphql/cloudshelf/mutations/ProductGroup.graphql
@@ -25,3 +25,13 @@ mutation deleteProductGroups($ids: [GlobalId!]!) {
         }
     }
 }
+
+mutation keepKnownProductGroupsViaFile($fileUrl: String!) {
+    keepKnownProductGroupsViaFile(fileUrl: $fileUrl) {
+        count
+        userErrors {
+            code
+            message
+        }
+    }
+}

--- a/src/modules/cloudshelf/cloudshelf.api.service.ts
+++ b/src/modules/cloudshelf/cloudshelf.api.service.ts
@@ -19,6 +19,9 @@ import {
     ExchangeTokenDocument,
     ExchangeTokenQuery,
     ExchangeTokenQueryVariables,
+    KeepKnownProductGroupsViaFileDocument,
+    KeepKnownProductGroupsViaFileMutation,
+    KeepKnownProductGroupsViaFileMutationVariables,
     KeepKnownProductsViaFileDocument,
     KeepKnownProductsViaFileMutation,
     KeepKnownProductsViaFileMutationVariables,
@@ -452,6 +455,25 @@ export class CloudshelfApiService {
         if (mutationTuple.errors) {
             console.log('Failed to handle keepKnownVariantsViaFile', mutationTuple.errors);
             await log?.('Failed to handle keepKnownVariantsViaFile' + inspect(mutationTuple.errors));
+        }
+    }
+
+    async keepKnownProductGroupsViaFile(domain: string, url: string, log?: (logMessage: string) => Promise<void>) {
+        const authedClient = await this.getCloudshelfAPIApolloClient(domain);
+
+        const mutationTuple = await authedClient.mutate<
+            KeepKnownProductGroupsViaFileMutation,
+            KeepKnownProductGroupsViaFileMutationVariables
+        >({
+            mutation: KeepKnownProductGroupsViaFileDocument,
+            variables: {
+                fileUrl: url,
+            },
+        });
+
+        if (mutationTuple.errors) {
+            console.log('Failed to handle keepKnownProductGroupsViaFile', mutationTuple.errors);
+            await log?.('Failed to handle keepKnownProductGroupsViaFile' + inspect(mutationTuple.errors));
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a feature allowing product groups to be updated via file upload, enhancing data management capabilities.
- **Enhancements**
	- Improved handling of product group content, including saving and uploading to cloud storage.
	- Streamlined the process for deleting product groups based on file content, ensuring more efficient data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->