### PR TITLE
fix: catalog stats are now only reported for full syncs

### DIFF
--- a/src/modules/data-ingestion/product/product.processor.ts
+++ b/src/modules/data-ingestion/product/product.processor.ts
@@ -523,21 +523,23 @@ export class ProductProcessor implements OnApplicationBootstrap {
         await this.nobleService.addTimedLogMessage(task, `Deleting downloaded data file: ${tempFile}`);
         await fsPromises.unlink(tempFile);
 
-        const sumOfVariants = variantInputs.reduce((acc, val) => acc + val.variants.length, 0);
-        const input = {
-            knownNumberOfProductGroups: undefined,
-            knownNumberOfProducts: productInputs.length,
-            knownNumberOfProductVariants: sumOfVariants,
-            knownNumberOfImages: imageCount,
-        };
-        await this.nobleService.addTimedLogMessage(
-            task,
-            `Reporting catalog stats to cloudshelf: ${JSON.stringify(input)}`,
-            true,
-        );
-        await this.cloudshelfApiService.reportCatalogStats(retailer.domain, input, async logMessage => {
-            await this.nobleService.addTimedLogMessage(task, logMessage, true);
-        });
+        if (runFullSyncLogic) {
+            const sumOfVariants = variantInputs.reduce((acc, val) => acc + val.variants.length, 0);
+            const input = {
+                knownNumberOfProductGroups: undefined,
+                knownNumberOfProducts: productInputs.length,
+                knownNumberOfProductVariants: sumOfVariants,
+                knownNumberOfImages: imageCount,
+            };
+            await this.nobleService.addTimedLogMessage(
+                task,
+                `Reporting catalog stats to cloudshelf: ${JSON.stringify(input)}`,
+                true,
+            );
+            await this.cloudshelfApiService.reportCatalogStats(retailer.domain, input, async logMessage => {
+                await this.nobleService.addTimedLogMessage(task, logMessage, true);
+            });
+        }
 
         await handleComplete('job complete', retailer);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logic for reporting catalog statistics to ensure it only runs when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->