### PR TITLE
CS-2828: forward structured Shopify location address to Cloudshelf

### DIFF
--- a/src/graphql/cloudshelf/generated/cloudshelf.ts
+++ b/src/graphql/cloudshelf/generated/cloudshelf.ts
@@ -2642,18 +2642,30 @@ export type LocationFilterInput = {
 
 /** This object represents a physical location, usually a store or a warehouse. */
 export type LocationInput = {
-    /** The full address of the location */
-    address?: InputMaybe<Scalars['String']['input']>;
+    /** Street address line 1. */
+    address1?: InputMaybe<Scalars['String']['input']>;
+    /** Street address line 2. */
+    address2?: InputMaybe<Scalars['String']['input']>;
+    /** City. */
+    city?: InputMaybe<Scalars['String']['input']>;
     /** The country code of the location is based */
     countryCode?: InputMaybe<CountryCode>;
     /** The display name of the location */
     displayName?: InputMaybe<Scalars['String']['input']>;
+    /** The email address of the location */
+    email?: InputMaybe<Scalars['String']['input']>;
     /** Whether the location fulfills online orders */
     fulfillsOnlineOrders?: InputMaybe<Scalars['Boolean']['input']>;
     /** Use this field to provide either a Cloudshelf gid, or your own external gid. If the external gid already exists, the existing record will be updated. If the external gid does not exist, a new record will be created. */
     id?: InputMaybe<Scalars['GlobalId']['input']>;
     /** An array of metadata to attach to the location */
     metadata?: InputMaybe<Array<MetadataInput>>;
+    /** Phone number for the location. */
+    phone?: InputMaybe<Scalars['String']['input']>;
+    /** ISO-3166-2 subdivision code (state / province / county). */
+    provinceCode?: InputMaybe<Scalars['String']['input']>;
+    /** Postal / ZIP code. */
+    zip?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type LocationPageInfo = {

--- a/src/graphql/shopifyAdmin/generated/shopifyAdmin.ts
+++ b/src/graphql/shopifyAdmin/generated/shopifyAdmin.ts
@@ -65026,6 +65026,12 @@ export const LocationAddressDetails = gql`
   formatted
   phone
   countryCode
+  address1
+  address2
+  city
+  province
+  provinceCode
+  zip
 }
     `;
 export const LocationDetails = gql`
@@ -65391,16 +65397,16 @@ export type GetDraftOrdersQueryVariables = Exact<{
 
 export type GetDraftOrdersQuery = { __typename?: 'QueryRoot', draftOrders: { __typename?: 'DraftOrderConnection', edges: Array<{ __typename?: 'DraftOrderEdge', cursor: string, node: { __typename?: 'DraftOrder', id: string, tags: Array<string>, email?: string | null, name: string, status: DraftOrderStatus, customAttributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, lineItems: { __typename?: 'DraftOrderLineItemConnection', nodes: Array<{ __typename?: 'DraftOrderLineItem', id: string, quantity: number, variant?: { __typename?: 'ProductVariant', id: string } | null }> } } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null } } };
 
-export type LocationAddressDetailsFragment = { __typename?: 'LocationAddress', formatted: Array<string>, phone?: string | null, countryCode?: string | null };
+export type LocationAddressDetailsFragment = { __typename?: 'LocationAddress', formatted: Array<string>, phone?: string | null, countryCode?: string | null, address1?: string | null, address2?: string | null, city?: string | null, province?: string | null, provinceCode?: string | null, zip?: string | null };
 
-export type LocationDetailsFragment = { __typename?: 'Location', id: string, name: string, isActive: boolean, fulfillsOnlineOrders: boolean, address: { __typename?: 'LocationAddress', formatted: Array<string>, phone?: string | null, countryCode?: string | null } };
+export type LocationDetailsFragment = { __typename?: 'Location', id: string, name: string, isActive: boolean, fulfillsOnlineOrders: boolean, address: { __typename?: 'LocationAddress', formatted: Array<string>, phone?: string | null, countryCode?: string | null, address1?: string | null, address2?: string | null, city?: string | null, province?: string | null, provinceCode?: string | null, zip?: string | null } };
 
 export type GetLocationsQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type GetLocationsQuery = { __typename?: 'QueryRoot', locations: { __typename?: 'LocationConnection', edges: Array<{ __typename?: 'LocationEdge', cursor: string, node: { __typename?: 'Location', id: string, name: string, isActive: boolean, fulfillsOnlineOrders: boolean, address: { __typename?: 'LocationAddress', formatted: Array<string>, phone?: string | null, countryCode?: string | null } } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null } } };
+export type GetLocationsQuery = { __typename?: 'QueryRoot', locations: { __typename?: 'LocationConnection', edges: Array<{ __typename?: 'LocationEdge', cursor: string, node: { __typename?: 'Location', id: string, name: string, isActive: boolean, fulfillsOnlineOrders: boolean, address: { __typename?: 'LocationAddress', formatted: Array<string>, phone?: string | null, countryCode?: string | null, address1?: string | null, address2?: string | null, city?: string | null, province?: string | null, provinceCode?: string | null, zip?: string | null } } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null } } };
 
 export type GetShopInformationQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/src/graphql/shopifyAdmin/queries/Locations.graphql
+++ b/src/graphql/shopifyAdmin/queries/Locations.graphql
@@ -2,6 +2,12 @@ fragment LocationAddressDetails on LocationAddress {
     formatted
     phone
     countryCode
+    address1
+    address2
+    city
+    province
+    provinceCode
+    zip
 }
 
 fragment LocationDetails on Location {

--- a/src/trigger/data-ingestion/retailer_sync/parts/__tests__/handleSyncLocations.test.ts
+++ b/src/trigger/data-ingestion/retailer_sync/parts/__tests__/handleSyncLocations.test.ts
@@ -30,7 +30,16 @@ describe('handleSyncLocations', () => {
                                     id: 'gid://shopify/Location/1',
                                     name: 'Loc 1',
                                     fulfillsOnlineOrders: true,
-                                    address: { formatted: ['Line 1'], countryCode: 'US' },
+                                    address: {
+                                        formatted: ['Line 1'],
+                                        countryCode: 'US',
+                                        address1: '123 Main St',
+                                        address2: 'Suite 4',
+                                        city: 'Milwaukee',
+                                        provinceCode: 'WI',
+                                        zip: '53202',
+                                        phone: '+14145551234',
+                                    },
                                 },
                             },
                         ],
@@ -47,7 +56,16 @@ describe('handleSyncLocations', () => {
                                     id: 'gid://shopify/Location/2',
                                     name: 'Loc 2',
                                     fulfillsOnlineOrders: false,
-                                    address: { formatted: ['Line 2'], countryCode: 'CA' },
+                                    address: {
+                                        formatted: ['Line 2'],
+                                        countryCode: 'CA',
+                                        address1: null,
+                                        address2: null,
+                                        city: null,
+                                        provinceCode: null,
+                                        zip: null,
+                                        phone: null,
+                                    },
                                 },
                             },
                         ],
@@ -75,17 +93,81 @@ describe('handleSyncLocations', () => {
                 {
                     id: 'gid://external/ShopifyLocation/1',
                     displayName: 'Loc 1',
-                    address: 'Line 1',
+                    address1: '123 Main St',
+                    address2: 'Suite 4',
+                    city: 'Milwaukee',
+                    provinceCode: 'WI',
+                    zip: '53202',
+                    phone: '+14145551234',
                     countryCode: 'US',
                     fulfillsOnlineOrders: true,
                 },
                 {
                     id: 'gid://external/ShopifyLocation/2',
                     displayName: 'Loc 2',
-                    address: 'Line 2',
+                    address1: 'unknown',
+                    address2: null,
+                    city: null,
+                    provinceCode: null,
+                    zip: null,
+                    phone: null,
                     countryCode: 'CA',
                     fulfillsOnlineOrders: false,
                 },
+            ],
+            expect.any(Object),
+        );
+    });
+
+    it("falls back address1 to 'unknown' when Shopify omits it or returns an empty string", async () => {
+        const query = jest.fn().mockResolvedValueOnce({
+            data: {
+                locations: {
+                    edges: [
+                        {
+                            node: {
+                                id: 'gid://shopify/Location/10',
+                                name: 'No-address loc',
+                                fulfillsOnlineOrders: true,
+                                address: {
+                                    formatted: [],
+                                    countryCode: 'GB',
+                                    address1: '',
+                                    address2: null,
+                                    city: null,
+                                    provinceCode: null,
+                                    zip: null,
+                                    phone: null,
+                                },
+                            },
+                        },
+                        {
+                            node: {
+                                id: 'gid://shopify/Location/11',
+                                name: 'Missing-address loc',
+                                fulfillsOnlineOrders: true,
+                                address: null,
+                            },
+                        },
+                    ],
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                },
+            },
+        });
+
+        (ShopifyGraphqlUtil.getShopifyAdminApolloClientByRetailer as jest.Mock).mockResolvedValue({ query });
+
+        const env = { CLOUDSHELF_API_URL: 'https://api.cloudshelf.test' } as any;
+        const retailer = { id: 'retailer_1', domain: 'test.myshopify.com' } as any;
+
+        await handleSyncLocations(env, {} as any, retailer, 'run_1');
+
+        expect(CloudshelfApiLocationUtils.upsertLocations).toHaveBeenCalledWith(
+            'https://api.cloudshelf.test',
+            retailer,
+            [
+                expect.objectContaining({ id: 'gid://external/ShopifyLocation/10', address1: 'unknown' }),
+                expect.objectContaining({ id: 'gid://external/ShopifyLocation/11', address1: 'unknown' }),
             ],
             expect.any(Object),
         );

--- a/src/trigger/data-ingestion/retailer_sync/parts/handleSyncLocations.ts
+++ b/src/trigger/data-ingestion/retailer_sync/parts/handleSyncLocations.ts
@@ -84,7 +84,22 @@ export async function handleSyncLocations(
         locationInputs.push(csLocation);
     }
 
-    logger.info('Creating location in Cloudshelf with data:', { locationInputs });
+    // Log a sanitized summary rather than the raw inputs — zip/phone/street
+    // are PII we shouldn't persist in our log pipeline.
+    logger.info('Creating locations in Cloudshelf', {
+        count: locationInputs.length,
+        locations: locationInputs.map(loc => ({
+            id: loc.id,
+            displayName: loc.displayName,
+            countryCode: loc.countryCode,
+            provinceCode: loc.provinceCode,
+            city: loc.city,
+            fulfillsOnlineOrders: loc.fulfillsOnlineOrders,
+            hasAddress1: !!loc.address1 && loc.address1 !== 'unknown',
+            hasZip: !!loc.zip,
+            hasPhone: !!loc.phone,
+        })),
+    });
 
     await CloudshelfApiLocationUtils.upsertLocations(env.CLOUDSHELF_API_URL, retailer, locationInputs, {
         info: (logMessage: string, ...args: any[]) => logger.info(logMessage, ...args),

--- a/src/trigger/data-ingestion/retailer_sync/parts/handleSyncLocations.ts
+++ b/src/trigger/data-ingestion/retailer_sync/parts/handleSyncLocations.ts
@@ -66,11 +66,17 @@ export async function handleSyncLocations(
     const locationInputs: LocationInput[] = [];
 
     for (const shopifyLocation of shopifyLocationData) {
-        const formattedAddress = (shopifyLocation.address?.formatted ?? []).join(', ');
+        // address1 is required by the Cloudshelf API on create; fall back to 'unknown' so locations
+        // without a street address in Shopify (rare, but possible) still sync instead of erroring.
         const csLocation: LocationInput = {
             id: GlobalIDUtils.gidConverter(shopifyLocation.id, 'ShopifyLocation'),
             displayName: shopifyLocation.name,
-            address: formattedAddress,
+            address1: shopifyLocation.address?.address1 || 'unknown',
+            address2: shopifyLocation.address?.address2 ?? null,
+            city: shopifyLocation.address?.city ?? null,
+            provinceCode: shopifyLocation.address?.provinceCode ?? null,
+            zip: shopifyLocation.address?.zip ?? null,
+            phone: shopifyLocation.address?.phone ?? null,
             countryCode: MiscellaneousUtils.convertCountryCode(shopifyLocation.address?.countryCode),
             fulfillsOnlineOrders: shopifyLocation.fulfillsOnlineOrders,
         };


### PR DESCRIPTION
## Summary
- Extend the `LocationAddressDetails` Shopify fragment with `address1`/`address2`/`city`/`province`/`provinceCode`/`zip`.
- In `handleSyncLocations`, forward these as structured fields on the Cloudshelf `LocationInput` instead of a single `formatted.join(', ')` string.
- Fall back `address1` to `'unknown'` when Shopify returns null/undefined/empty, since the Cloudshelf API requires it on create.

## Why
Pair PR with [Cloudshelf/cloudshelf-api#1008](https://github.com/Cloudshelf/cloudshelf-api/pull/1008) — the API now carries structured address fields so Shopifys tax engine can compute a jurisdiction when a customer pays on a Cloudshelf device without providing a delivery address.

## Deploy runbook
1. Merge + deploy cloudshelf-api#1008 first so the GraphQL schema accepts the new `LocationInput` shape.
2. Rerun `npm run codegen:cloudshelf` + `npm run codegen:shopifyAdmin` locally against the deployed schema to regenerate the hand-patched type files (they will regenerate identically).
3. Deploy this PR.
4. Enqueue a location re-sync for every installed store so Shopify-sourced locations get real structured address data (overwrites the migrations copied-from-legacy `address1`).

## Test plan
- [x] `npm run tests:typecheck`
- [x] `npm run tests:unittest -- --testPathPattern='handleSyncLocations'` → 3/3
- [ ] Real US store re-sync: verify cloudshelf-api `location` row has `provinceCode`, `zip`, `city`, `address1` populated.
- [ ] Real UK store re-sync: same.
- [ ] Store configured without a street address in Shopify: re-sync succeeds; `address1` stored as `'unknown'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
