### PR TITLE
chore(deps): bump axios to 1.15.0 via @slack/web-api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8655,12 +8655,12 @@
       }
     },
     "node_modules/@slack/logger": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
-      "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.1.tgz",
+      "integrity": "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": ">=18.0.0"
+        "@types/node": ">=18"
       },
       "engines": {
         "node": ">= 18",
@@ -8668,9 +8668,9 @@
       }
     },
     "node_modules/@slack/types": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.16.0.tgz",
-      "integrity": "sha512-bICnyukvdklXhwxprR3uF1+ZFkTvWTZge4evlCS4G1H1HU6QLY68AcjqzQRymf7/5gNt6Y4OBb4NdviheyZcAg==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.20.1.tgz",
+      "integrity": "sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==",
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0",
@@ -8678,16 +8678,16 @@
       }
     },
     "node_modules/@slack/web-api": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.10.0.tgz",
-      "integrity": "sha512-kT+07JvOqpYH3b/ttVo3iqKIFiHV2NKmD6QUc/F7HrjCgSdSA10zxqi0euXEF2prB49OU7SfjadzQ0WhNc7tiw==",
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.1.tgz",
+      "integrity": "sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg==",
       "license": "MIT",
       "dependencies": {
-        "@slack/logger": "^4.0.0",
-        "@slack/types": "^2.9.0",
-        "@types/node": ">=18.0.0",
+        "@slack/logger": "^4.0.1",
+        "@slack/types": "^2.20.1",
+        "@types/node": ">=18",
         "@types/retry": "0.12.0",
-        "axios": "^1.11.0",
+        "axios": "^1.15.0",
         "eventemitter3": "^5.0.1",
         "form-data": "^4.0.4",
         "is-electron": "2.2.2",


### PR DESCRIPTION
## Summary
- Aikido flagged axios <1.15.0 CVEs.
- `axios` is a transitive dep via `@slack/web-api`. Updating `@slack/web-api` from 7.10.0 → 7.15.1 (within the existing `^7.0.1` range) resolves `axios` to `1.15.0`.
- No direct code changes required.

## Test plan
- [x] `npm run tests:typecheck` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)