### PR TITLE
chore(deps): force systeminformation to ^5.31.0 via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9582,32 +9582,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@trigger.dev/core/node_modules/systeminformation": {
-      "version": "5.23.8",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.23.8.tgz",
-      "integrity": "sha512-Osd24mNKe6jr/YoXLLK3k8TMdzaxDffhpCxgkfgBHcapykIkd50HXThM3TCEuHO2pPuCsSx2ms/SunqhU5MmsQ==",
-      "license": "MIT",
-      "os": [
-        "darwin",
-        "linux",
-        "win32",
-        "freebsd",
-        "openbsd",
-        "netbsd",
-        "sunos",
-        "android"
-      ],
-      "bin": {
-        "systeminformation": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "Buy me a coffee",
-        "url": "https://www.buymeacoffee.com/systeminfo"
-      }
-    },
     "node_modules/@trigger.dev/sdk": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/@trigger.dev/sdk/-/sdk-4.4.3.tgz",
@@ -21262,9 +21236,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.1",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.1.tgz",
-      "integrity": "sha512-6pRwxoGeV/roJYpsfcP6tN9mep6pPeCtXbUOCdVa0nme05Brwcwdge/fVNhIZn2wuUitAKZm4IYa7QjnRIa9zA==",
+      "version": "5.31.5",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.5.tgz",
+      "integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -239,7 +239,8 @@
   },
   "overrides": {
     "minimatch": ">=10.2.1",
-    "lodash": "^4.18.1"
+    "lodash": "^4.18.1",
+    "systeminformation": "^5.31.0"
   },
   "jest": {
     "roots": [


### PR DESCRIPTION
## Summary
- Aikido flagged systeminformation <5.31.0 CVEs.
- systeminformation is a transitive dep via `@opentelemetry/host-metrics` — pulled in by both `@trigger.dev/core` (`@opentelemetry/host-metrics@0.37.0` → `systeminformation@5.23.8`) and `nestjs-otel`.
- Adds an npm `overrides` entry pinning every systeminformation instance to `^5.31.0` (now resolves to 5.31.5).

## Test plan
- [x] `npm run tests:typecheck` passes
- [x] `npm ls systeminformation` shows ≥5.31.0 everywhere
- [ ] CI green
