### PR TITLE
chore(deps): force knex to ^3.2.9 via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17355,9 +17355,9 @@
       }
     },
     "node_modules/knex": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-3.2.8.tgz",
-      "integrity": "sha512-ElXXxu9Nq+5hWYdBUddYIWIT5yKKs5KNCsmKGbJSHPyaMpAABp3xs4L55GgdQoAs6QQ7dv72ai3M4pxYQ8utEg==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-3.2.9.tgz",
+      "integrity": "sha512-dtAILTjBMaG8YloP5oBxohDIKyIsdQ/TkcVvSjhsksvsjeH63Y0PADyuMDfNZKbVT3Rlx3vEYVBlecbPT/KerA==",
       "license": "MIT",
       "dependencies": {
         "colorette": "2.0.19",

--- a/package.json
+++ b/package.json
@@ -240,7 +240,8 @@
   "overrides": {
     "minimatch": ">=10.2.1",
     "lodash": "^4.18.1",
-    "systeminformation": "^5.31.0"
+    "systeminformation": "^5.31.0",
+    "knex": "^3.2.9"
   },
   "jest": {
     "roots": [


### PR DESCRIPTION
## Summary
- Aikido flagged knex <3.2.9 CVEs.
- knex is a transitive dep via `@mikro-orm/knex` (which pins knex to exactly 3.2.8).
- Adds an npm `overrides` entry pinning every knex instance to `^3.2.9`.
- In cloudshelf-api only: knex 3.2.9's stricter `RawBinding` types exposed one narrowing issue in `product-binary-generator.ts` where `filters.productGroupIds` was captured inside an `andWhere` callback; assigned to a local const so the `string[]` narrow type survives.

## Test plan
- [x] `npm run tests:typecheck` passes
- [ ] CI green
