### PR TITLE
chore(deps): force protobufjs to ^8.0.1 via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19644,9 +19644,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
+      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -241,7 +241,8 @@
     "minimatch": ">=10.2.1",
     "lodash": "^4.18.1",
     "systeminformation": "^5.31.0",
-    "knex": "^3.2.9"
+    "knex": "^3.2.9",
+    "protobufjs": "^8.0.1"
   },
   "jest": {
     "roots": [


### PR DESCRIPTION
## Summary
- Aikido flagged `CVE-2026-41242` (Critical) and `AIKIDO-2026-10467` (Medium) against protobufjs <8.0.1.
- protobufjs is a transitive dep via `@grpc/proto-loader`, `@opentelemetry/otlp-transformer`, `google-gax`, and `@google-cloud/firestore`.
- Adds an npm `overrides` entry pinning every protobufjs instance to `^8.0.1`. This covers both the critical and medium advisories (7.5.5 would fix only the critical).
- Major-version bump under parents that declare `^7.5.3`; typecheck + the full `src/` Jest suite (145 suites / 1654 tests) pass, so the API surface we actually exercise is compatible.

## Test plan
- [x] `npm run tests:typecheck` passes
- [x] `npm ls protobufjs` → every node now 8.0.1
- [x] `src/` Jest suite passes (1654 tests, 0 failures)
- [ ] CI green
