### PR TITLE
fix: clean up trigger_job_record rows on cancellation

### DIFF
--- a/src/trigger/init.ts
+++ b/src/trigger/init.ts
@@ -112,3 +112,23 @@ tasks.onFailure(async ({ ctx, error, payload }) => {
         }
     }
 });
+
+tasks.onCancel(async ({ ctx, payload }) => {
+    logger.info(`[JobTracking] onCancel: task=${ctx.task.id} run=${ctx.run.id}`);
+
+    const domain = await getRetailerDomain(payload);
+    if (domain) {
+        try {
+            const env = getEnvConfig();
+            const client = await CloudshelfApiAuthUtils.getCloudshelfAPIApolloClient(env.CLOUDSHELF_API_URL, domain);
+            await client.mutate<ReportTriggerJobFailedMutation, ReportTriggerJobFailedMutationVariables>({
+                mutation: ReportTriggerJobFailedDocument,
+                variables: { taskId: ctx.task.id, runId: ctx.run.id },
+            });
+        } catch (error) {
+            logger.warn('[JobTracking] Failed to report job cancelled', {
+                error: error instanceof Error ? error.message : String(error),
+            });
+        }
+    }
+});


### PR DESCRIPTION
## Summary

- Add a global `tasks.onCancel` hook in `src/trigger/init.ts` that reports cancellation via the existing `reportTriggerJobFailed` GraphQL mutation
- Companion to https://github.com/Cloudshelf/cloudshelf-api/pull/1028 — the API-side delete by `runId` is identical for failed/cancelled, so no new mutation was added
- Previously, cancelled runs stayed visible in the manager UI for up to 24h until the stale-record sweep ran

## Test plan

- [x] `npm run tests:typecheck` passes
- [x] Prettier clean on modified file
- [ ] Manually cancel a running task and confirm the row disappears on the API side

🤖 Generated with [Claude Code](https://claude.com/claude-code)