### PR TITLE
fix: stop prepending namespace prefix to metadata keys

### DIFF
--- a/src/trigger/data-ingestion/retailer_sync/parts/handleSyncProducts.ts
+++ b/src/trigger/data-ingestion/retailer_sync/parts/handleSyncProducts.ts
@@ -132,10 +132,7 @@ export async function handleSyncProducts(
                     const normalizedNamespace = (metafield.namespace ?? '').trim().toLowerCase() || 'global';
                     const metafieldInput: MetadataInput = {
                         id: GlobalIDUtils.gidConverter(metafield.id, 'ShopifyMetafield'),
-                        key:
-                            normalizedNamespace !== 'global'
-                                ? `${normalizedNamespace}-${metafield.key}`
-                                : metafield.key,
+                        key: metafield.key,
                         namespace: normalizedNamespace,
                         data: metafield.value,
                     };
@@ -210,10 +207,7 @@ export async function handleSyncProducts(
                         const normalizedNamespace = (metafield.namespace ?? '').trim().toLowerCase() || 'global';
                         variantMetadata.push({
                             id: GlobalIDUtils.gidConverter(metafield.id, 'ShopifyMetafield'),
-                            key:
-                                normalizedNamespace !== 'global'
-                                    ? `${normalizedNamespace}-${metafield.key}`
-                                    : metafield.key,
+                            key: metafield.key,
                             namespace: normalizedNamespace,
                             data: metafield.value,
                         });


### PR DESCRIPTION
## Summary
- The Shopify connector previously stored metafield keys as `${namespace}-${key}` whenever the namespace was non-global, while also setting `namespace` separately on the same record. This double-encoding made the manager UI render metadata as `Metadata custom-bredde` even though the namespace was already known.
- This PR removes the prefix and sends the raw key (with namespace as a separate field) for both product and variant metafield sync.
- Pairs with [Cloudshelf/cloudshelf-api](https://github.com/Cloudshelf/cloudshelf-api)#XXX (which adds the migration to strip the prefix from existing rows and surfaces `namespace` end-to-end) and the matching cloudshelf-manager change.

## Test plan
- [ ] Trigger a fresh retailer sync in dev with a non-global metafield (e.g. `namespace=custom`, `key=bredde`)
- [ ] Confirm the `Metadata` row in the API DB has `key=bredde` and `namespace=custom` (not `key=custom-bredde`)
- [ ] Verify variant metafields land with the same shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)
