### PR TITLE
fix: stabilize production build entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY .env .env
 RUN npm run build
 
 EXPOSE 3123
-CMD ["node", "dist/src/main.js"]
+CMD ["node", "dist/main.js"]

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "--- prod options ---": "",
     "prebuild": "rimraf dist",
     "build": "nest build",
-    "start:prod": "node dist/src/main.js",
+    "start:prod": "node dist/main.js",
     "--- other ---": "",
     "postinstall": "patch-package && npx license-report --output=markdown --only=prod --fields=name --fields=installedVersion --fields=licenseType --fields=author --fields=link > LICENSES.md",
     "--- trigger ---": "",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Summary
- Restores production startup commands to `dist/main.js`.
- Constrains the Nest build to `src/**/*.ts` so local and Docker builds produce the same output layout.

## Root Cause
The previous fix was verified against a local build that also compiled root-level `trigger.config.ts`. That made TypeScript preserve the `src/` directory under `dist`, producing `dist/src/main.js`. The Dockerfile only copies `src/` into the image before building, so the container build produced `dist/main.js` instead. Deployment then failed because the Docker `CMD` pointed at `dist/src/main.js`, which does not exist in the image.

## Validation
- `npm run build` now emits `dist/main.js` locally.
- `npm run tests:typecheck`
- `npm run tests:unittest` (9 suites, 39 tests)
- `ENV_FILE_PATH=environment-variables/.local NODE_OPTIONS='--trace-warnings --trace-deprecation' npm run start:prod` starts via `node dist/main.js`.
- `docker build -t shopify-connector-entrypoint-check .` completed using a temporary local `.env` file for the existing Docker `COPY .env .env` step.
- `docker run --rm --entrypoint node shopify-connector-entrypoint-check -e "..."` confirmed `{ main: true, nested: false }` for `dist/main.js` and `dist/src/main.js`.

## Notes
The local `start:prod` smoke test runs the app's normal boot path, which includes MikroORM migrations. I stopped the process after startup and reverted the generated migration snapshot side effect before committing.
